### PR TITLE
jsondump observer now contains protocol (request+response)

### DIFF
--- a/src/observers/jsondump.py
+++ b/src/observers/jsondump.py
@@ -16,6 +16,7 @@
 
 from src.observers.base import BaseResultsObserver
 import json
+import time
 
 
 class Observer(BaseResultsObserver):
@@ -23,11 +24,30 @@ class Observer(BaseResultsObserver):
     A results observer that prints results to standard output.
     """
 
+    def __init__(self, manager):
+        super(Observer, self).__init__(manager)
+        self.currentProtocol = []
+
     def updateCalls(self):
         super(Observer, self).updateCalls()
         self._calls.update({
             "finish": self.finish,
+            "protocol": self.protocol,
+            "testSuite": self.testSuite,
+            "testResult": self.testResult,
         })
+
+    def protocol(self, result):
+        self.currentProtocol.append(result)
+
+    def testResult(self, result):
+        result["time"] = time.time()
+        if self.currentProtocol:
+            result["protocol"] = self.currentProtocol
+            self.currentProtocol = []
+
+    def testSuite(self, result):
+        result["time"] = time.time()
 
     def finish(self):
         print json.dumps(self.manager.results)

--- a/verifiers/statusCode.py
+++ b/verifiers/statusCode.py
@@ -37,4 +37,4 @@ class Verifier(object):
             if result:
                 return True, ""
 
-        return False, "        HTTP Status Code Wrong: %d" % (response.status,)
+        return False, "        HTTP Status Code Wrong (expected %s): %d" % (", ".join(teststatus), response.status,)


### PR DESCRIPTION
By submitting a request, you represent that you have the right to license
your contribution to Apple and the community, and agree that your
contributions are licensed under the [Apache License Version 2.0](LICENSE.txt).

For existing files modified by your request, you represent that you have
retained any existing copyright notices and licensing terms. For each new
file in your request, you represent that you have added to the file a
copyright notice (including the year and the copyright owner's name) and the
Calendar and Contacts Server's licensing terms.

Before submitting the request, please make sure that your request follows
the [Calendar and Contacts Server's guidelines for contributing
code](../../../ccs-calendarserver/blob/master/HACKING.rst).

enabled via --print-details-onfail, --always-print-request or --always-print-response parameter
also added timestamp for each test